### PR TITLE
Upgrade go version and linter

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -24,4 +24,4 @@ jobs:
       - name: golangci-lint
         uses: golangci/golangci-lint-action@971e284b6050e8a5849b72094c50ab08da042db8 # v3.7.1
         with:
-          version: v1.54
+          version: v1.60.3

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -71,22 +71,8 @@ linters-settings:
   gocritic:
     enabled-checks:
       # Diagnostic
-      - appendAssign
-      - argOrder
-      - badCond
-      - caseOrder
-      - codegenComment
       - commentedOutCode
-      - deprecatedComment
-      - dupArg
-      - dupBranchBody
-      - dupCase
-      - dupSubExpr
-      - exitAfterDefer
-      - flagDeref
-      - flagName
       - nilValReturn
-      - offBy1
       - sloppyReassign
       - weakCond
       - octalLiteral
@@ -100,31 +86,16 @@ linters-settings:
       - rangeValCopy
 
       # Style
-      - assignOp
       - boolExprSimplify
-      - captLocal
-      - commentFormatting
       - commentedOutImport
-      - defaultCaseOrder
       - docStub
-      - elseif
       - emptyFallthrough
       - emptyStringTest
       - hexLiteral
       - methodExprCall
-      - regexpMust
-      - singleCaseSwitch
-      - sloppyLen
       - stringXbytes
-      - switchTrue
       - typeAssertChain
-      - typeSwitchVar
-      - underef
       - unlabelStmt
-      - unlambda
-      - unslice
-      - valSwap
-      - wrapperFunc
       - yodaStyleExpr
       # - ifElseChain
 

--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ release:
 # used when need to validate the goreleaser
 .PHONY: snapshot
 snapshot:
-	LDFLAGS="$(LDFLAGS)" goreleaser release --skip-sign --skip-publish --snapshot --clean
+	LDFLAGS="$(LDFLAGS)" goreleaser release --skip=sign --skip=publish --snapshot --clean
 
 .PHONY: clean
 clean:

--- a/go.mod
+++ b/go.mod
@@ -1,7 +1,6 @@
 module github.com/clebs/kubeglass
 
 go 1.23.2
-toolchain go1.23
 
 require (
 	github.com/google/go-cmp v0.6.0

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,7 @@
 module github.com/clebs/kubeglass
 
-go 1.21.6
+go 1.23.2
+toolchain go1.23
 
 require (
 	github.com/google/go-cmp v0.6.0


### PR DESCRIPTION
- Upgrade go to 1.23
- Upgrade linter to 1.60
- Adjust deprecated flags in goreleaser